### PR TITLE
Github actions part 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: Build Project
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  backend:
+    name: "Build SpacetimeDB Module"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Setup .NET"
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8'
+      - name: "Setup build env"
+        run: |
+          sudo apt-get update && sudo apt-get install -y binaryen
+          dotnet workload install wasi-experimental
+          curl -sL https://github.com/clockworklabs/SpacetimeDB/releases/latest/download/spacetime.linux-amd64.tar.gz | sudo tar -xzC /usr/bin/
+          sudo chmod +x /usr/bin/spacetime
+      - name: "Build module"
+        run: |
+          spacetime build -p server
+          mv server/obj/Release/net8.0/wasi-wasm/wasm/for-publish/StdbModule.wasm pogly.wasm
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: spacetimedb-module
+          path: pogly.wasm
+          overwrite: true
+
+  frontend:
+    name: "Build Web"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Setup node.js"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: "Build web"
+        run: |
+          npm install
+          npm run build
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-files
+          path: build/
+          overwrite: true
+
+  deploy:
+    name: "Deploy"
+    needs: frontend
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,16 @@
-name: Build Project
+name: Build
 
 on:
   push:
-  pull_request:
+    branches-ignore:
+      - refs/tags/v*
+  release:
+    types:
+      - created
 
 jobs:
   backend:
-    name: "Build SpacetimeDB Module"
+    name: "SpacetimeDB Module"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +36,7 @@ jobs:
           overwrite: true
 
   frontend:
-    name: "Build Web"
+    name: "Web"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,5 +59,16 @@ jobs:
   deploy:
     name: "Deploy"
     needs: frontend
+    if: >
+      github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev' ||
+      startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/deploy.yml
+    secrets: inherit
+
+  release:
+    name: "Release"
+    needs: [ backend, frontend ]
+    if: github.event_name == 'release'
+    uses: ./.github/workflows/release.yml
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Project
+name: Deploy
 
 on:
   workflow_call:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy Project
+
+on:
+  workflow_call:
+
+jobs:
+  deploy_web:
+    name: "${{ matrix.target }}"
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        target: [ dev, prod ]
+        isProd:
+          - ${{ contains(github.ref, 'main') || startsWith(github.ref, 'refs/tags/v') }}
+        exclude:
+          - isProd: false
+            target: prod
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: web-files
+      - uses: easingthemes/ssh-deploy@v5.1.0
+        with:
+          REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
+          REMOTE_USER: ${{ secrets.REMOTE_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.REMOTE_SSH_KEY }}
+          SOURCE: "."
+          TARGET: "${{ secrets.REMOTE_DIR }}/${{ matrix.target }}"
+          ARGS: "-avzr --delete"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,13 @@
-name: Build Docker Images
+name: Docker
 
 on:
   push:
-    branches: [main, gh_actions]
+    branches: [main]
     tags: ['v*']
 
 jobs:
   docker:
-    name: "Build Docker image"
+    name: "Build Image"
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,33 +1,49 @@
-name: Build and Push Docker Images
+name: Build Docker Images
 
 on:
   push:
-    branches: [main]
+    branches: [main, gh_actions]
+    tags: ['v*']
 
 jobs:
   docker:
-    name: "Build and Push"
+    name: "Build Docker image"
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+
     steps:
-      - name: lowercase repo owner
+      - name: "lowercase repo owner"
         run: |
           echo "GITHUB_OWNER_LC=${GITHUB_OWNER,,}" >>${GITHUB_ENV}
         env:
           GITHUB_OWNER: '${{ github.repository_owner }}'
       - uses: actions/checkout@v4
-      - uses: docker/login-action@v2
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
-          username: ${{ env.GITHUB_OWNER_LC }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v3
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ env.GITHUB_OWNER_LC }}/pogly
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
-          tags: ghcr.io/${{ env.GITHUB_OWNER_LC }}/pogly:latest
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=registry,ref=user/app:latest
+          cache-to: type=inline
+
   delete_old_packages:
     name: "Delete old Packages"
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  workflow_call:
+
+jobs:
+  upload_assets:
+    name: "Upload Assets"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+      - run: |
+          mkdir assets
+          cd web-files
+          tar -czf ../assets/pogly-web.tar.gz *
+          cd ..
+          mv spacetimedb-module/pogly.wasm assets/pogly-spacetimedb-module.wasm
+      - uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: assets/*


### PR DESCRIPTION
Adds github actions for:
- Building frontend and backend and adding them as artifacts to the run
- Deploying frontend to a server of choice
  - main branch and all releases to the prod & dev folders ( test site https://pogly.noxal.net )
  - dev branch to dev folder  ( test site https://pogly-dev.noxal.net )
- Attaching built artifacts to a given release

Standard build: https://github.com/Noxal/pogly-standalone/actions/runs/10551803033
Release build: https://github.com/Noxal/pogly-standalone/actions/runs/10551807863
Release with autobuilt assets: https://github.com/Noxal/pogly-standalone/releases/tag/v0.1.2

One minor detail is that the deploy job must run on a self-hosted runner, github doesn't like the ssh stuff on their runners. Another option is to deploy it to github pages instead, but that only allows a single deployment (ie prod only)

Github actions leaves a lot to be desired in terms of dependencies across workflows so both release and deploy are triggered from the build file in order to not build the entire thing 2 or 3 times for a release or commit to main.