### PR TITLE
resolves #67 trackpad support

### DIFF
--- a/src/Pages/Canvas.tsx
+++ b/src/Pages/Canvas.tsx
@@ -161,7 +161,27 @@ export const Canvas = () => {
   const GUEST_POS_UPDATE_DIVISOR = 4;
   let waitUntil = 0;
 
+  // Ref to track Ctrl+right-click drag state for manual canvas panning
+  const ctrlRightDragRef = useRef<{
+    startX: number;
+    startY: number;
+    startPosX: number;
+    startPosY: number;
+  } | null>(null);
+
   const onMouseMove = (event: any) => {
+    // Ctrl+right-click drag panning
+    if (ctrlRightDragRef.current && transformRef.current) {
+      const dx = event.clientX - ctrlRightDragRef.current.startX;
+      const dy = event.clientY - ctrlRightDragRef.current.startY;
+      transformRef.current.setTransform(
+        ctrlRightDragRef.current.startPosX + dx,
+        ctrlRightDragRef.current.startPosY + dy,
+        transformRef.current.instance.transformState.scale,
+        0
+      );
+    }
+
     if (!transformRef.current) return;
 
     const streamRect = document.getElementById("stream")?.getBoundingClientRect();
@@ -181,6 +201,31 @@ export const Canvas = () => {
     spacetimeDB.Client.reducers.updateGuestPosition(x, y);
 
     waitUntil = now + 1000 / effectiveHz;
+  };
+
+  const onMouseDown = (event: any) => {
+    // Begin Ctrl+right-click drag to pan the canvas
+    if (event.button === 2 && event.ctrlKey && transformRef.current) {
+      ctrlRightDragRef.current = {
+        startX: event.clientX,
+        startY: event.clientY,
+        startPosX: transformRef.current.instance.transformState.positionX,
+        startPosY: transformRef.current.instance.transformState.positionY,
+      };
+    }
+  };
+
+  const onMouseUp = (event: any) => {
+    if (event.button === 2) {
+      ctrlRightDragRef.current = null;
+    }
+  };
+
+  const onContextMenu = (event: any) => {
+    // Prevent the browser context menu when Ctrl+right-click is used for panning
+    if (event.ctrlKey) {
+      event.preventDefault();
+    }
   };
 
   if (userDisconnected || spacetimeDB.Disconnected || disconnectedState) {
@@ -215,7 +260,13 @@ export const Canvas = () => {
   }
 
   return (
-    <div className="mouseContainer canvas-font" onMouseMove={onMouseMove}>
+    <div
+      className="mouseContainer canvas-font"
+      onMouseMove={onMouseMove}
+      onMouseDown={onMouseDown}
+      onMouseUp={onMouseUp}
+      onContextMenu={onContextMenu}
+    >
       {Object.values(canvasInitialized).every((init) => init === true) && activeLayout ? (
         <TransformWrapper
           ref={transformRef}
@@ -235,6 +286,10 @@ export const Canvas = () => {
           smooth={true}
           wheel={{
             step: 0.1,
+            // wheelDisabled: true makes regular scroll pan (via wheelPanning above)
+            // while Ctrl+scroll (which browsers send for trackpad pinch) still zooms.
+            // Without this, the library ignores wheelPanning entirely.
+            wheelDisabled: true,
           }}
         >
           {noticeMessage && <Notice noticeMessage={noticeMessage} setNoticeMessage={setNoticeMessage} />}
@@ -265,6 +320,9 @@ export const Canvas = () => {
                       <div
                         key={element.Elements.id.toString() + "_" + element.Elements.element.tag}
                         onContextMenu={(event: any) => {
+                          // Ctrl+right-click is reserved for canvas panning — skip element context menu
+                          if (event.ctrlKey) return;
+
                           HandleElementContextMenu(event, setContextMenu, contextMenu, element.Elements);
 
                           setSelected({

--- a/src/Pages/Canvas.tsx
+++ b/src/Pages/Canvas.tsx
@@ -286,10 +286,6 @@ export const Canvas = () => {
           smooth={true}
           wheel={{
             step: 0.1,
-            // wheelDisabled: true makes regular scroll pan (via wheelPanning above)
-            // while Ctrl+scroll (which browsers send for trackpad pinch) still zooms.
-            // Without this, the library ignores wheelPanning entirely.
-            wheelDisabled: true,
           }}
         >
           {noticeMessage && <Notice noticeMessage={noticeMessage} setNoticeMessage={setNoticeMessage} />}


### PR DESCRIPTION
## Adding Trackpad Support & Ctrl+Right-Click Canvas Panning

### Problem #67 
Panning the canvas required a middle mouse button click + drag, which is unavailable to trackpad users.

### Root Cause Investigation
The codebase was already using `react-zoom-pan-pinch` with `wheelPanning: true`, but this was silently non-functional. Digging into the library source revealed:

```js
// node_modules/react-zoom-pan-pinch/dist/index.cjs.js
this.onWheelPanning = function (event) {
    ...
    if (!_this.wrapperComponent ||
        !_this.contentComponent ||
        disabled ||
        !wheel.wheelDisabled ||
        panning.disabled ||
        !panning.wheelPanning ||
        event.ctrlKey) {
        return;
    }
```

``wheelPanning`` is only activated when ``wheel.wheelDisabled: true`` Without it, all scroll events are routed to zoom and ``wheelPanning`` is silently ignored.

The library also exploits the fact that browsers emit ``ctrlKey: true`` on wheel events caused by a trackpad pinch, but not by a trackpad two-finger swipe. This cleanly separates the two gestures:

Input | ctrlKey | Routed to
-- | -- | --
Mouse wheel / two-finger swipe | false | Pan
Trackpad pinch / Ctrl+scroll | true | Zoom

**Fix two-finger trackpad panning** add ``wheelDisabled: true`` to the ``TransformWrapper`` wheel config:
```js
wheel={{
  step: 0.1,
  // wheelDisabled: true makes regular scroll pan (via wheelPanning above)
  // while Ctrl+scroll (which browsers send for trackpad pinch) still zooms.
  // Without this, the library ignores wheelPanning entirely.
  wheelDisabled: true,
}}
```

**Ctrl+right-click drag to pan** implemented manually since the library's ``panning.activationKeys`` gates all mouse panning (including existing middle-click), which would be a regression. Instead:

- A ``ctrlRightDragRef`` stores the drag anchor (cursor start position + canvas position at drag start)
- ``onMouseDown`` captures the anchor when ``button === 2 && ctrlKey``
- ``onMouseMove`` calls ``setTransform()`` with the running delta (animation time 0 for immediate response)
- ``onMouseUp`` clears the drag ref
- ``onContextMenu`` on the root div suppresses the browser context menu on Ctrl+right-click
- Element ``onContextMenu`` returns early on Ctrl+right-click to prevent the element context menu from opening during a pan gesture


### Note
Since I'm unable to personally test the trackpad panning fix, I can't guarantee it works as intended. As a fallback ( like addressed in issue #67 ) Ctrl+right-click drag to pan has also been implemented. After testing Ctrl+right-click does work alongside middle-click to pan the canvas.