### PR TITLE
docs: fix onboarding pogly setup link

### DIFF
--- a/src/Pages/Login/Components/ModuleOnboarding.tsx
+++ b/src/Pages/Login/Components/ModuleOnboarding.tsx
@@ -434,15 +434,6 @@ export const ModuleOnboarding = ({ connectionConfig, spacetime }: IProps) => {
                 <p>
                   To start using Pogly on your stream, you need to create a new browser source in your OBS/StreamLabs
                   and paste the Pogly overlay URL into it.
-                  <a
-                    href="https://docs.pogly.gg/#getting-started"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-[10px] text-[#82a5ff] Geist-light"
-                  >
-                    <br />
-                    (How to add Pogly to your OBS/StreamLabs)
-                  </a>
                 </p>
                 <StyledButton
                   onClick={() => {

--- a/src/Pages/Login/Components/ModuleOnboarding.tsx
+++ b/src/Pages/Login/Components/ModuleOnboarding.tsx
@@ -435,7 +435,7 @@ export const ModuleOnboarding = ({ connectionConfig, spacetime }: IProps) => {
                   To start using Pogly on your stream, you need to create a new browser source in your OBS/StreamLabs
                   and paste the Pogly overlay URL into it.
                   <a
-                    href="https://github.com/PoglyApp/pogly-documentation/blob/main/use/firstTimeSetup.md#obs--streamlabs-browser-source"
+                    href="https://docs.pogly.gg/#getting-started"
                     target="_blank"
                     rel="noreferrer"
                     className="text-[10px] text-[#82a5ff] Geist-light"


### PR DESCRIPTION
<img width="1538" height="813" alt="image" src="https://github.com/user-attachments/assets/6a1365c4-b359-4742-967d-5a2e630c1320" />
<img width="1797" height="675" alt="image" src="https://github.com/user-attachments/assets/2e74978a-53d0-4e6b-98bf-405a1d3807d1" />


The url on how to add pogly does not exist. [Check Here](https://github.com/PoglyApp/pogly-documentation/blob/main/use/firstTimeSetup.md#obs--streamlabs-browser-source)

This fix updates onboarding url